### PR TITLE
Support for animation

### DIFF
--- a/HPLTagCloudGenerator.h
+++ b/HPLTagCloudGenerator.h
@@ -7,6 +7,16 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface HPLTagCloudTag : NSObject
++ (HPLTagCloudTag *)tagWithSize:(CGSize)size center:(CGPoint)center scale:(float)scale;
+- (instancetype)initWithSize:(CGSize)size center:(CGPoint)center scale:(float)scale;
+
+@property (nonatomic) CGSize size;
+@property (nonatomic) CGPoint center;
+@property (nonatomic) float scale;
+@end
 
 @interface HPLTagCloudGenerator : NSObject
 
@@ -34,7 +44,10 @@
 @property float b;
 
 
-// Returns an array of views.
-- (NSArray *)generateTagViews;
+// Returns a dictionary with tags. Safe to call from any thread.
+- (NSDictionary *)generateTags;
+
+// Create or update tag views.
+- (NSDictionary *)updateViews:(NSDictionary *)oldViews inView:(UIView *)view withTags:(NSDictionary *)tags animate:(BOOL)animate;
 
 @end

--- a/HPLTagCloudGenerator.h
+++ b/HPLTagCloudGenerator.h
@@ -43,6 +43,8 @@
 @property float a;
 @property float b;
 
+// Returns an array of views.
+- (NSArray *)generateTagViews __attribute__((deprecated));
 
 // Returns a dictionary with tags. Safe to call from any thread.
 - (NSDictionary *)generateTags;

--- a/HPLTagCloudGenerator.m
+++ b/HPLTagCloudGenerator.m
@@ -192,6 +192,20 @@
     return tags;
 }
 
-
+- (NSArray *)generateTagViews {
+  NSDictionary *tags = [self generateTags];
+  NSMutableArray *views = [NSMutableArray arrayWithCapacity:tags.count];
+  for (NSString *tagKey in tags) {
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+    HPLTagCloudTag *tag = tags[tagKey];
+    label.text = tagKey;
+    label.font = [UIFont systemFontOfSize:kFontSize];
+    label.transform = CGAffineTransformMakeScale(tag.scale, tag.scale);
+    label.bounds = CGRectMake(0, 0, tag.size.width, tag.size.height);
+    label.center = tag.center;
+    [views addObject:label];
+  }
+  return [views copy];
+}
 
 @end

--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ dispatch_async( dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
     tagGenerator.size = CGSizeMake(self.tagView.frame.size.width, self.tagView.frame.size.height);
     tagGenerator.tagDict = tagDict;
 
-    NSArray *views = [tagGenerator generateTagViews];
+    // Generate tags.
+    NSDictionary *tags = [tagGenerator generateTags];
 
     dispatch_async( dispatch_get_main_queue(), ^{
         // This runs in the UI Thread
 
-        for(UIView *v in views) {
-            // Add tags to the view we created it for
-            [self.tagView addSubview:v];
-        }
+        // Add tags to the view we created it for.
+        self.tagLabelViews = [tagGenerator updateViews:self.tagLabelViews inView:self.tagView withTags:tags animate:YES];
+
+        // Calling updateViews again will move existing tags to their new position, as well as create and remove tags as
+        // needed. With animate:YES all label transitions will be animated.
 
     });
 });


### PR DESCRIPTION
I had need for a tag cloud that could be animated, so I modified HPLTagCloudGenerator to support animations. Since you can't animate font size, I used a fixed font size together with an affine transform to size the labels. 

The new version is completely backward compatible, but you do need to use the new method to get support for animation.